### PR TITLE
feat(invoices): add invoice submission endpoint with field validation and verification pipeline

### DIFF
--- a/backend/api/routes/invoice.routes.ts
+++ b/backend/api/routes/invoice.routes.ts
@@ -1,21 +1,25 @@
 import { Router, Request, Response } from "express";
 import { authMiddleware, AuthRequest } from "../middlewares/auth.middleware";
 import { rbac } from "../middlewares/rbac.middleware";
+import { submitInvoice } from "../../modules/invoices/invoice.controller";
 import { verifyInvoice } from "../../modules/verification/verifier.service";
 
 const router = Router();
 
-// VENDOR only
+// VENDOR — submit an invoice (validated + verified)
+router.post("/", authMiddleware, rbac(["VENDOR"]), submitInvoice);
+
+// VENDOR — upload placeholder
 router.post("/upload", authMiddleware, rbac(["VENDOR"]), (req: AuthRequest, res: Response) => {
     res.json({ message: "Invoice uploaded", user: req.user });
 });
 
-// ADMIN + LENDER
+// ADMIN + LENDER — verify an invoice
 router.get("/verify", authMiddleware, rbac(["ADMIN", "LENDER"]), (req: AuthRequest, res: Response) => {
     res.json({ message: "Invoice verification access granted", user: req.user });
 });
 
-// Test the verification pipeline (no auth for testing)
+// Test the verification pipeline (no auth — for dev only)
 router.post("/verify-test", async (req: Request, res: Response) => {
     try {
         const result = await verifyInvoice(req.body);
@@ -26,3 +30,4 @@ router.post("/verify-test", async (req: Request, res: Response) => {
 });
 
 export default router;
+

--- a/backend/modules/invoices/invoice.controller.ts
+++ b/backend/modules/invoices/invoice.controller.ts
@@ -1,0 +1,33 @@
+import { Request, Response } from "express";
+import { verifyInvoice } from "../verification/verifier.service";
+import { InvoiceInput } from "../../shared/types";
+
+/** POST /api/invoices — submit an invoice for verification */
+export async function submitInvoice(req: Request, res: Response): Promise<void> {
+    const body = req.body as InvoiceInput;
+
+    // Basic field validation
+    const missing = validateRequired(body);
+    if (missing.length > 0) {
+        res.status(400).json({ error: `Missing required fields: ${missing.join(", ")}` });
+        return;
+    }
+
+    try {
+        const result = await verifyInvoice(body);
+        res.status(200).json(result);
+    } catch (err) {
+        res.status(500).json({ error: String(err) });
+    }
+}
+
+function validateRequired(body: InvoiceInput): string[] {
+    const missing: string[] = [];
+    if (!body.invoiceNumber) missing.push("invoiceNumber");
+    if (!body.sellerGSTIN) missing.push("sellerGSTIN");
+    if (!body.buyerGSTIN) missing.push("buyerGSTIN");
+    if (!body.invoiceDate) missing.push("invoiceDate");
+    if (body.invoiceAmount == null) missing.push("invoiceAmount");
+    if (!body.lineItems || body.lineItems.length === 0) missing.push("lineItems");
+    return missing;
+}


### PR DESCRIPTION
- Add invoice controller with submitInvoice handler that validates required
  fields (invoiceNumber, sellerGSTIN, buyerGSTIN, invoiceDate, invoiceAmount,
  lineItems) before running the verification pipeline
- Add POST /api/invoices route protected by authMiddleware + rbac(["VENDOR"])
- Wire invoice controller to verifier.service for end-to-end processing:
  submit → validate → canonicalize → hash → IRN check → Redis dedup → respond
- Keep POST /api/invoices/verify-test as unprotected dev-only route for testing